### PR TITLE
Use pre-commit for linting.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,43 @@
+name: Lint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+    type: [ "opened", "reopened", "synchronize" ]
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.cache/pre-commit
+          key:
+            lint-v1-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/.pre-commit-config.yaml') }}
+          restore-keys: |
+            lint-v1-
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install pre-commit
+      - name: Lint
+        run: |
+          pre-commit run --all-files --show-diff-on-failure
+        env:
+          PRE_COMMIT_COLOR: always

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,37 @@
+exclude:
+  'bootstrap.py|tests/templates/*'
+repos:
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v3.4.0
+      hooks:
+          - id: trailing-whitespace
+          - id: end-of-file-fixer
+          - id: fix-encoding-pragma
+            args: [--remove]
+          - id: check-yaml
+          - id: debug-statements
+            language_version: python3
+    - repo: https://gitlab.com/pycqa/flake8
+      rev: 3.8.4
+      hooks:
+          - id: flake8
+            language_version: python3
+            additional_dependencies: [flake8-typing-imports==1.9.0]
+    - repo: https://github.com/pre-commit/mirrors-autopep8
+      rev: v1.5.4
+      hooks:
+          - id: autopep8
+    - repo: https://github.com/timothycrosley/isort
+      rev: 5.6.4
+      hooks:
+      - id: isort
+        args: [--filter-files]
+        files: \.py$
+    - repo: local
+      hooks:
+          - id: rst
+            name: rst
+            entry: rst-lint --encoding utf-8
+            files: .rst
+            language: python
+            additional_dependencies: [pygments, restructuredtext_lint]

--- a/gobre/recipe/template/__init__.py
+++ b/gobre/recipe/template/__init__.py
@@ -5,15 +5,14 @@ Buildout recipe for making files out of Jinja2 templates.
 __author__ = 'Torgeir Lorange Ostby <torgeilo@gmail.com>'
 __version__ = '1.2.4'
 
+from zc.recipe.egg.egg import Eggs
+from zope.dottedname.resolve import resolve as resolve_dotted
+import jinja2
 import logging
 import os
 import re
 import sys
-
-import jinja2
 import zc.buildout
-from zc.recipe.egg.egg import Eggs
-from zope.dottedname.resolve import resolve as resolve_dotted
 
 
 log = logging.getLogger(__name__)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,10 @@
+[bdist_wheel]
+universal = 1
+
+[isort]
+lines_between_sections = 0
+lines_after_imports = 2
+no_sections = True
+from_first = True
+lines_between_types = 0
+force_single_line = True

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages
+from setuptools import setup
+
 
 setup(
     name="gobre.recipe.template",

--- a/tests/filters.py
+++ b/tests/filters.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 def riba(s):
     """docstring for riba"""

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -1,6 +1,5 @@
 import os
 import unittest
-
 import zc.buildout.buildout
 
 


### PR DESCRIPTION
Let's use pre-commit for linting now. In case of a failure it is typically fixed (isort, flake8) and the commit is aborted and can be (re-)viewed again.